### PR TITLE
build: Remove push events to master from workflow triggers 

### DIFF
--- a/.github/workflows/security-check.yml
+++ b/.github/workflows/security-check.yml
@@ -1,9 +1,6 @@
 name: "Security Check"
 
 on:
-  push:
-    branches:
-      - master
   pull_request:
     branches:
       - master

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -2,9 +2,6 @@ name: Test Coverage
 run-name: Test Coverage
 
 on:
-  push:
-    branches:
-      - master
   pull_request:
     branches:
       - master


### PR DESCRIPTION
The security-check and test-coverage workflows have been updated to no longer trigger on push events to the master branch. These changes limit the workflows to only run on pull requests, streamlining our CI/CD process and saving resources.