### PR TITLE
fix(httpproxy): remove unused resolver handling code

### DIFF
--- a/nanoproxy.go
+++ b/nanoproxy.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"github.com/caarlos0/env/v10"
 	"github.com/rs/zerolog"
 	"github.com/ryanbekhen/nanoproxy/pkg/config"
@@ -100,7 +101,7 @@ func main() {
 			IdleTimeout:  60 * time.Second,
 		}
 
-		if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		if err := server.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
 			logger.Fatal().Msg(err.Error())
 		}
 	}()

--- a/pkg/httpproxy/httpproxy.go
+++ b/pkg/httpproxy/httpproxy.go
@@ -170,22 +170,6 @@ func (s *Server) handleHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	destAddr := r.URL.Host
-	if s.config.Resolver != nil {
-		ip, err := s.config.Resolver.Resolve(destAddr)
-		if err != nil {
-			latency := time.Since(startTime).Milliseconds()
-			s.config.Logger.Error().
-				Str("client_addr", clientIP).
-				Str("dest_addr", r.URL.String()).
-				Str("latency", fmt.Sprintf("%dms", latency)).
-				Msg("Failed to resolve destination - Bad Gateway")
-			http.Error(w, "Bad gateway: failed to resolve destination", http.StatusBadGateway)
-			return
-		}
-		destAddr = net.JoinHostPort(ip.String(), r.URL.Port())
-	}
-
 	proxyReq, err := http.NewRequest(r.Method, r.URL.String(), r.Body)
 	if err != nil {
 		latency := time.Since(startTime).Milliseconds()

--- a/pkg/httpproxy/httpproxy_test.go
+++ b/pkg/httpproxy/httpproxy_test.go
@@ -92,7 +92,7 @@ func TestServer_ServeHTTP(t *testing.T) {
 	})
 
 	t.Run("Handle HTTP - successful authorization but Dial fails", func(t *testing.T) {
-		req := httptest.NewRequest(http.MethodGet, "http://example.com", nil)
+		req := httptest.NewRequest(http.MethodGet, "https://badgatewaytesting.com", nil)
 		req.Header.Set("Proxy-Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte("user:password")))
 		rr := httptest.NewRecorder()
 

--- a/pkg/httpproxy/httpproxy_test.go
+++ b/pkg/httpproxy/httpproxy_test.go
@@ -102,14 +102,14 @@ func TestServer_ServeHTTP(t *testing.T) {
 	})
 
 	t.Run("Handle HTTP - failed to resolve host", func(t *testing.T) {
-		req := httptest.NewRequest(http.MethodGet, "http://invalidhost.com", nil)
+		req := httptest.NewRequest(http.MethodGet, "http://invalidhostinvalidhostinvalidhost.com", nil)
 		req.Header.Set("Proxy-Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte("user:password")))
 		rr := httptest.NewRecorder()
 
 		server.ServeHTTP(rr, req)
 
 		assert.Equal(t, http.StatusBadGateway, rr.Code)
-		assert.Contains(t, rr.Body.String(), "Bad gateway: failed to resolve destination")
+		assert.Contains(t, rr.Body.String(), "Bad gateway: failed to send request")
 	})
 }
 

--- a/pkg/httpproxy/httpproxy_test.go
+++ b/pkg/httpproxy/httpproxy_test.go
@@ -291,10 +291,7 @@ func TestServer_HandleHTTP_ClientDoError(t *testing.T) {
 
 		server.ServeHTTP(rr, proxyReq)
 
-		// Kode status harus 502: Bad Gateway karena resolve gagal
 		assert.Equal(t, http.StatusBadGateway, rr.Code)
-
-		// Validasi pesan error
-		assert.Contains(t, rr.Body.String(), "Bad gateway: failed to resolve destination")
+		assert.Contains(t, rr.Body.String(), "Bad gateway: failed to send request")
 	})
 }


### PR DESCRIPTION
Removed redundant destination resolution code from httpproxy. Simplified error handling by replacing custom logic with the standard library's `errors.Is` for clearer and more concise behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling in server shutdown process.
	- Updated error messaging for request handling failures.

- **Refactor**
	- Removed destination address resolution logic in HTTP proxy handling.
	- Modified test cases to simulate more extreme invalid host scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->