### PR TITLE
feat:Add NO_AUTH_MODE to disable proxy authentication and skip admin server

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -5,6 +5,7 @@ on:
   push:
     tags:
       - v*
+      - "*"
 
 permissions:
   contents: write
@@ -20,9 +21,9 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v5
         with:
-          go-version: 1.26
+          go-version-file: go.mod
 
       - run: go mod download
 
@@ -34,6 +35,12 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Validate release secrets
+        shell: bash
+        run: |
+          test -n "${{ secrets.GH_PAT }}" || { echo "GH_PAT is required"; exit 1; }
+          test -n "${{ secrets.FURY_TOKEN }}" || { echo "FURY_TOKEN is required"; exit 1; }
 
       - uses: goreleaser/goreleaser-action@v6
         if: success() && startsWith(github.ref, 'refs/tags/')

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -199,7 +199,8 @@ publishers:
     ids:
       - packages
     dir: "{{ dir .ArtifactPath }}"
-    cmd: curl -F package=@{{ .ArtifactName }} https://{{ .Env.FURY_TOKEN }}@push.fury.io/ryanbekhen/
+    cmd: >-
+      bash -euo pipefail -c 'test -n "{{ .Env.FURY_TOKEN }}" || { echo "FURY_TOKEN is not set"; exit 1; }; echo "Uploading {{ .ArtifactName }} to Fury"; curl --silent --show-error --fail-with-body --retry 3 --retry-all-errors -F "package=@{{ .ArtifactName }}" "https://{{ .Env.FURY_TOKEN }}@push.fury.io/ryanbekhen/"'
 
 release:
   name_template: "{{ .Version }}"

--- a/README.md
+++ b/README.md
@@ -226,12 +226,21 @@ configuration options, environment variable reference, and examples, see [docs/C
 export ADDR=:1080
 export ADDR_HTTP=:8080
 export ADDR_ADMIN=:9090
+export NO_AUTH_MODE=false
 export LOG_LEVEL=info
 export USER_STORE_PATH=./nanoproxy-data.db
 ```
 
 Then access the admin panel at `http://localhost:9090/admin/setup` to create your initial admin account and add proxy
 users.
+
+To run without proxy authentication:
+
+```shell
+export NO_AUTH_MODE=true
+```
+
+When `NO_AUTH_MODE=true`, admin server is also automatically disabled.
 
 ## Logging
 
@@ -286,6 +295,8 @@ curl -x http://localhost:8080 -U username:password https://example.com
 
 If authentication fails or is not provided, the proxy will return `407 Proxy Authentication Required` along with the
 appropriate `Proxy-Authenticate` header.
+
+When `NO_AUTH_MODE=true`, both HTTP and SOCKS5 accept anonymous clients and no credentials are required.
 
 ## Contributions
 

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -43,6 +43,12 @@ NanoProxy is configured entirely through environment variables. There is no conf
 | `ADMIN_LOCKOUT_DURATION`   | duration     | `10m`   | Duration to lock account after max failed attempts                                               |
 | `ADMIN_ALLOWED_ORIGINS`    | string (csv) | empty   | Comma-separated list of allowed CORS origins for admin panel (e.g., `https://admin.example.com`) |
 
+### Proxy Authentication Mode
+
+| Variable       | Type | Default | Description                                                                       |
+|----------------|------|---------|-----------------------------------------------------------------------------------|
+| `NO_AUTH_MODE` | bool | `false` | Disable proxy auth for SOCKS5/HTTP and skip admin server startup (`true`/`false`) |
+
 ### Tor Integration
 
 | Variable                | Type     | Default | Description                                                    |
@@ -71,6 +77,16 @@ LOG_LEVEL=info
 ```
 
 Then access the admin console to create users.
+
+### Headless Proxy (No Admin + No Auth)
+
+```bash
+ADDR=:1080
+ADDR_HTTP=:8080
+NO_AUTH_MODE=true
+```
+
+Use this mode when you only need proxy forwarding and do not want the admin HTTP surface.
 
 ### Production Deployment
 
@@ -179,7 +195,7 @@ WantedBy=multi-user.target
 
 ## Admin Console and Persistent Proxy Users
 
-NanoProxy starts an admin console on `ADDR_ADMIN`.
+NanoProxy starts an admin console on `ADDR_ADMIN` in normal mode (`NO_AUTH_MODE=false`).
 
 - Visit `/` or `/admin` on the admin address.
 - On first run (when no admin exists in `USER_STORE_PATH`), create the admin account at `/admin/setup`.
@@ -219,6 +235,7 @@ go run .
 - Admin panel is accessible at `http://localhost:9090` (or configured `ADDR_ADMIN`)
 - Initial admin account is set up through the `/admin/setup` web interface on first run
 - Proxy users can be created and managed through the admin panel
+- Set `NO_AUTH_MODE=true` to allow unauthenticated proxy traffic and skip admin startup
 - For production, always use `LOG_LEVEL=warn` or `error` to reduce log noise
 - Database file location should be on persistent storage in containers/orchestration
 

--- a/nanoproxy.go
+++ b/nanoproxy.go
@@ -48,7 +48,10 @@ func main() {
 	if err != nil {
 		logger.Fatal().Err(err).Msg("Failed to initialize credentials")
 	}
-	adminStore := admin.NewBoltAdminStore(cfg.UserStorePath)
+	proxyCredentials := proxyCredentialsForMode(cfg, credentials)
+	if cfg.NoAuthMode {
+		logger.Warn().Msg("NO_AUTH_MODE is enabled; HTTP and SOCKS5 proxy authentication is disabled and admin server is skipped")
+	}
 
 	dnsResolver := &resolver.DNSResolver{}
 	trafficTracker := traffic.NewTracker()
@@ -60,7 +63,7 @@ func main() {
 	}
 
 	httpConfig := httpproxy.Config{
-		Credentials:       credentials,
+		Credentials:       proxyCredentials,
 		Logger:            &logger,
 		DestConnTimeout:   cfg.DestTimeout,
 		ClientConnTimeout: cfg.ClientTimeout,
@@ -95,9 +98,9 @@ func main() {
 		}()
 	}
 
-	if credentials != nil {
+	if proxyCredentials != nil {
 		authenticator := &socks5.UserPassAuthenticator{
-			Credentials: credentials,
+			Credentials: proxyCredentials,
 		}
 		socks5Config.Authentication = append(socks5Config.Authentication, authenticator)
 	}
@@ -127,35 +130,40 @@ func main() {
 		}
 	}()
 
-	adminServer := admin.New(&admin.Config{
-		Credentials:      credentials,
-		UserStore:        userFileStore,
-		AdminStore:       adminStore,
-		TrafficStore:     trafficStore,
-		Tracker:          trafficTracker,
-		CookieSecure:     cfg.AdminCookieSecure,
-		MaxLoginAttempts: cfg.AdminMaxLoginAttempts,
-		LoginWindow:      cfg.AdminLoginWindow,
-		LockoutDuration:  cfg.AdminLockoutDuration,
-		AllowedOrigins:   cfg.AdminAllowedOrigins,
-		Logger:           &logger,
-	})
+	if adminEnabledForMode(cfg) {
+		adminStore := admin.NewBoltAdminStore(cfg.UserStorePath)
+		adminServer := admin.New(&admin.Config{
+			Credentials:      credentials,
+			UserStore:        userFileStore,
+			AdminStore:       adminStore,
+			TrafficStore:     trafficStore,
+			Tracker:          trafficTracker,
+			CookieSecure:     cfg.AdminCookieSecure,
+			MaxLoginAttempts: cfg.AdminMaxLoginAttempts,
+			LoginWindow:      cfg.AdminLoginWindow,
+			LockoutDuration:  cfg.AdminLockoutDuration,
+			AllowedOrigins:   cfg.AdminAllowedOrigins,
+			Logger:           &logger,
+		})
 
-	go func() {
-		logger.Info().Msgf("Starting admin server on %s", cfg.ADDRAdmin)
+		go func() {
+			logger.Info().Msgf("Starting admin server on %s", cfg.ADDRAdmin)
 
-		server := &http.Server{
-			Addr:         cfg.ADDRAdmin,
-			Handler:      adminServer.Handler(),
-			ReadTimeout:  15 * time.Second,
-			WriteTimeout: 15 * time.Second,
-			IdleTimeout:  60 * time.Second,
-		}
+			server := &http.Server{
+				Addr:         cfg.ADDRAdmin,
+				Handler:      adminServer.Handler(),
+				ReadTimeout:  15 * time.Second,
+				WriteTimeout: 15 * time.Second,
+				IdleTimeout:  60 * time.Second,
+			}
 
-		if err := server.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
-			logger.Fatal().Msg(err.Error())
-		}
-	}()
+			if err := server.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+				logger.Fatal().Msg(err.Error())
+			}
+		}()
+	} else {
+		logger.Info().Msg("Admin server startup is skipped in NO_AUTH_MODE")
+	}
 
 	select {}
 }
@@ -169,4 +177,18 @@ func buildCredentialStore(cfg *config.Config) (*credential.StaticCredentialStore
 	}
 
 	return credentials, userStore, nil
+}
+
+func proxyCredentialsForMode(cfg *config.Config, credentials *credential.StaticCredentialStore) credential.Store {
+	if cfg != nil && cfg.NoAuthMode {
+		return nil
+	}
+	return credentials
+}
+
+func adminEnabledForMode(cfg *config.Config) bool {
+	if cfg == nil {
+		return true
+	}
+	return !cfg.NoAuthMode
 }

--- a/nanoproxy_test.go
+++ b/nanoproxy_test.go
@@ -36,3 +36,47 @@ func TestBuildCredentialStore_LoadsFromDatabase(t *testing.T) {
 		t.Fatal("expected db-user to be valid from database")
 	}
 }
+
+func TestProxyCredentialsForMode_NoAuthEnabled(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.Config{NoAuthMode: true}
+	credentials := credential.NewStaticCredentialStore()
+	credentials.Add("db-user", "password")
+
+	selected := proxyCredentialsForMode(cfg, credentials)
+	if selected != nil {
+		t.Fatal("expected nil credentials in NO_AUTH_MODE")
+	}
+}
+
+func TestProxyCredentialsForMode_NoAuthDisabled(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.Config{NoAuthMode: false}
+	credentials := credential.NewStaticCredentialStore()
+	credentials.Add("db-user", "password")
+
+	selected := proxyCredentialsForMode(cfg, credentials)
+	if selected == nil {
+		t.Fatal("expected non-nil credentials when NO_AUTH_MODE is disabled")
+	}
+}
+
+func TestAdminEnabledForMode_NoAuthEnabled(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.Config{NoAuthMode: true}
+	if adminEnabledForMode(cfg) {
+		t.Fatal("expected admin to be disabled when NO_AUTH_MODE is enabled")
+	}
+}
+
+func TestAdminEnabledForMode_NoAuthDisabled(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.Config{NoAuthMode: false}
+	if !adminEnabledForMode(cfg) {
+		t.Fatal("expected admin to be enabled when NO_AUTH_MODE is disabled")
+	}
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -9,6 +9,7 @@ type Config struct {
 	ADDR                  string        `env:"ADDR" envDefault:":1080"`
 	ADDRHttp              string        `env:"ADDR_HTTP" envDefault:":8080"`
 	ADDRAdmin             string        `env:"ADDR_ADMIN" envDefault:":9090"`
+	NoAuthMode            bool          `env:"NO_AUTH_MODE" envDefault:"false"`
 	UserStorePath         string        `env:"USER_STORE_PATH" envDefault:"nanoproxy-data.db"`
 	AdminCookieSecure     bool          `env:"ADMIN_COOKIE_SECURE" envDefault:"false"`
 	AdminMaxLoginAttempts int           `env:"ADMIN_MAX_LOGIN_ATTEMPTS" envDefault:"5"`

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,0 +1,33 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/caarlos0/env/v10"
+)
+
+func TestConfig_DefaultNoAuthMode(t *testing.T) {
+	t.Parallel()
+
+	cfg := &Config{}
+	if err := env.Parse(cfg); err != nil {
+		t.Fatalf("parse config: %v", err)
+	}
+
+	if cfg.NoAuthMode {
+		t.Fatal("expected NO_AUTH_MODE default to false")
+	}
+}
+
+func TestConfig_ParseNoAuthModeFromEnv(t *testing.T) {
+	t.Setenv("NO_AUTH_MODE", "true")
+
+	cfg := &Config{}
+	if err := env.Parse(cfg); err != nil {
+		t.Fatalf("parse config: %v", err)
+	}
+
+	if !cfg.NoAuthMode {
+		t.Fatal("expected NO_AUTH_MODE=true from environment")
+	}
+}


### PR DESCRIPTION
This pull request introduces a new "headless" or "no-auth" mode to NanoProxy, allowing the proxy to run without authentication and disabling the admin server when `NO_AUTH_MODE=true`. It also improves the documentation and robustness of the release process. The most important changes are grouped below:

**No-Auth Mode Implementation and Behavior:**

* Added a new `NO_AUTH_MODE` environment variable to the configuration (`pkg/config/config.go`), which disables proxy authentication for both HTTP and SOCKS5 and skips admin server startup when set to `true`. [[1]](diffhunk://#diff-a3d824da3c42420cd5cbb0a4a2c0e7b5bfddd819652788a0596d195dc6e31fa5R12) F4f3fe42L43R43, [[2]](diffhunk://#diff-abbd6017292bdf5c645e0d886693e622bf2d1d7f0893748d194449c9342f6016L63-R66) [[3]](diffhunk://#diff-abbd6017292bdf5c645e0d886693e622bf2d1d7f0893748d194449c9342f6016L98-R103) [[4]](diffhunk://#diff-abbd6017292bdf5c645e0d886693e622bf2d1d7f0893748d194449c9342f6016R133-R134) [[5]](diffhunk://#diff-abbd6017292bdf5c645e0d886693e622bf2d1d7f0893748d194449c9342f6016R164-R166) [[6]](diffhunk://#diff-abbd6017292bdf5c645e0d886693e622bf2d1d7f0893748d194449c9342f6016R181-R194)
* Introduced helper functions `proxyCredentialsForMode` and `adminEnabledForMode` to cleanly handle logic for enabling/disabling authentication and admin server based on the new mode.
* Added comprehensive tests to ensure correct behavior of the new mode and configuration parsing. [[1]](diffhunk://#diff-ecff4cf331b47e057256e6b79311e4619f85c7c643f2184f85f899eea7c06b4cR39-R82) [[2]](diffhunk://#diff-29cea1b5b831c8655c7155f43e2367cec73e66d1e338f8b3c7877a2f339b8811R1-R33)

**Documentation Updates:**

* Updated `README.md` and `docs/CONFIG.md` to document the new `NO_AUTH_MODE` option, including usage instructions, configuration table, and behavioral notes for running without authentication or admin server. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R229-R244) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R299-R300) [[3]](diffhunk://#diff-ed97b806cc8d5a740609f925aad9014e8c916832befd26fd8fe632682349c90bR46-R51) [[4]](diffhunk://#diff-ed97b806cc8d5a740609f925aad9014e8c916832befd26fd8fe632682349c90bR81-R90) [[5]](diffhunk://#diff-ed97b806cc8d5a740609f925aad9014e8c916832befd26fd8fe632682349c90bL182-R198) [[6]](diffhunk://#diff-ed97b806cc8d5a740609f925aad9014e8c916832befd26fd8fe632682349c90bR238)

**Release and CI Improvements:**

* Improved the GitHub Actions workflow by updating Go setup to use version 5 and reference the Go version from `go.mod`, and added a step to validate required release secrets. [[1]](diffhunk://#diff-4d14704b6b88fb06db888f96c03a8e9b3a5e07a4ee566d97d4111b2c05210e84L23-R26) [[2]](diffhunk://#diff-4d14704b6b88fb06db888f96c03a8e9b3a5e07a4ee566d97d4111b2c05210e84R39-R44)
* Enhanced `goreleaser` publishing by adding robust error handling and retry logic for the Fury upload command, and requiring the `FURY_TOKEN` to be set.
* Expanded the release workflow to trigger on all tags, not just those starting with `v`.