### PR TITLE
fix(no-auth): skip credential and traffic DB initialization in NO_AUTH_MODE

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ To run without proxy authentication:
 export NO_AUTH_MODE=true
 ```
 
-When `NO_AUTH_MODE=true`, admin server is also automatically disabled.
+When `NO_AUTH_MODE=true`, admin server is also automatically disabled and `USER_STORE_PATH` is ignored.
 
 ## Logging
 
@@ -296,7 +296,8 @@ curl -x http://localhost:8080 -U username:password https://example.com
 If authentication fails or is not provided, the proxy will return `407 Proxy Authentication Required` along with the
 appropriate `Proxy-Authenticate` header.
 
-When `NO_AUTH_MODE=true`, both HTTP and SOCKS5 accept anonymous clients and no credentials are required.
+When `NO_AUTH_MODE=true`, both HTTP and SOCKS5 accept anonymous clients, no credentials are required, and startup skips
+database-backed user/traffic loading.
 
 ## Contributions
 

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -45,9 +45,9 @@ NanoProxy is configured entirely through environment variables. There is no conf
 
 ### Proxy Authentication Mode
 
-| Variable       | Type | Default | Description                                                                       |
-|----------------|------|---------|-----------------------------------------------------------------------------------|
-| `NO_AUTH_MODE` | bool | `false` | Disable proxy auth for SOCKS5/HTTP and skip admin server startup (`true`/`false`) |
+| Variable       | Type | Default | Description                                                                           |
+|----------------|------|---------|---------------------------------------------------------------------------------------|
+| `NO_AUTH_MODE` | bool | `false` | Disable proxy auth, skip admin startup, and ignore `USER_STORE_PATH` (`true`/`false`) |
 
 ### Tor Integration
 
@@ -235,7 +235,7 @@ go run .
 - Admin panel is accessible at `http://localhost:9090` (or configured `ADDR_ADMIN`)
 - Initial admin account is set up through the `/admin/setup` web interface on first run
 - Proxy users can be created and managed through the admin panel
-- Set `NO_AUTH_MODE=true` to allow unauthenticated proxy traffic and skip admin startup
+- Set `NO_AUTH_MODE=true` to allow unauthenticated proxy traffic and skip admin/database-backed state loading
 - For production, always use `LOG_LEVEL=warn` or `error` to reduce log noise
 - Database file location should be on persistent storage in containers/orchestration
 

--- a/nanoproxy.go
+++ b/nanoproxy.go
@@ -50,16 +50,19 @@ func main() {
 	}
 	proxyCredentials := proxyCredentialsForMode(cfg, credentials)
 	if cfg.NoAuthMode {
-		logger.Warn().Msg("NO_AUTH_MODE is enabled; HTTP and SOCKS5 proxy authentication is disabled and admin server is skipped")
+		logger.Warn().Msg("NO_AUTH_MODE is enabled; proxy authentication, admin server, and database-backed state loading are skipped")
 	}
 
 	dnsResolver := &resolver.DNSResolver{}
 	trafficTracker := traffic.NewTracker()
 
-	// Load persisted traffic totals
-	trafficStore := traffic.NewBoltStore(cfg.UserStorePath)
-	if err := trafficTracker.LoadPersistedTotals(trafficStore); err != nil {
-		logger.Warn().Err(err).Msg("Failed to load persisted traffic totals")
+	trafficStore := trafficStoreForMode(cfg)
+	if trafficStore != nil {
+		if err := trafficTracker.LoadPersistedTotals(trafficStore); err != nil {
+			logger.Warn().Err(err).Msg("Failed to load persisted traffic totals")
+		}
+	} else if cfg.NoAuthMode {
+		logger.Info().Msg("Traffic persistence is disabled in NO_AUTH_MODE")
 	}
 
 	httpConfig := httpproxy.Config{
@@ -169,7 +172,18 @@ func main() {
 }
 
 func buildCredentialStore(cfg *config.Config) (*credential.StaticCredentialStore, credential.PersistentStore, error) {
-	userStore := credential.NewBoltStore(cfg.UserStorePath)
+	if cfg == nil {
+		return nil, nil, fmt.Errorf("config is nil")
+	}
+
+	noAuthMode := cfg.NoAuthMode
+	userStorePath := cfg.UserStorePath
+
+	if noAuthMode {
+		return credential.NewStaticCredentialStore(), nil, nil
+	}
+
+	userStore := credential.NewBoltStore(userStorePath)
 
 	credentials := credential.NewStaticCredentialStore()
 	if err := credential.LoadInto(userStore, credentials); err != nil {
@@ -191,4 +205,11 @@ func adminEnabledForMode(cfg *config.Config) bool {
 		return true
 	}
 	return !cfg.NoAuthMode
+}
+
+func trafficStoreForMode(cfg *config.Config) traffic.Store {
+	if cfg == nil || cfg.NoAuthMode {
+		return nil
+	}
+	return traffic.NewBoltStore(cfg.UserStorePath)
 }

--- a/nanoproxy_test.go
+++ b/nanoproxy_test.go
@@ -37,6 +37,26 @@ func TestBuildCredentialStore_LoadsFromDatabase(t *testing.T) {
 	}
 }
 
+func TestBuildCredentialStore_NoAuthModeSkipsDatabase(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.Config{
+		NoAuthMode:    true,
+		UserStorePath: filepath.Join(t.TempDir(), "missing", "data.db"),
+	}
+
+	credentials, userStore, err := buildCredentialStore(cfg)
+	if err != nil {
+		t.Fatalf("buildCredentialStore returned error: %v", err)
+	}
+	if credentials == nil {
+		t.Fatal("expected non-nil in-memory credentials in NO_AUTH_MODE")
+	}
+	if userStore != nil {
+		t.Fatal("expected nil persistent user store in NO_AUTH_MODE")
+	}
+}
+
 func TestProxyCredentialsForMode_NoAuthEnabled(t *testing.T) {
 	t.Parallel()
 
@@ -78,5 +98,23 @@ func TestAdminEnabledForMode_NoAuthDisabled(t *testing.T) {
 	cfg := &config.Config{NoAuthMode: false}
 	if !adminEnabledForMode(cfg) {
 		t.Fatal("expected admin to be enabled when NO_AUTH_MODE is disabled")
+	}
+}
+
+func TestTrafficStoreForMode_NoAuthEnabled(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.Config{NoAuthMode: true}
+	if store := trafficStoreForMode(cfg); store != nil {
+		t.Fatal("expected nil traffic store in NO_AUTH_MODE")
+	}
+}
+
+func TestTrafficStoreForMode_NoAuthDisabled(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.Config{NoAuthMode: false, UserStorePath: filepath.Join(t.TempDir(), "data.db")}
+	if store := trafficStoreForMode(cfg); store == nil {
+		t.Fatal("expected non-nil traffic store when NO_AUTH_MODE is disabled")
 	}
 }


### PR DESCRIPTION
This pull request improves the handling of the `NO_AUTH_MODE` configuration option to ensure that, when enabled, the application skips all database-backed state loading (including user and traffic data), ignores the `USER_STORE_PATH`, and disables related persistence. The documentation is updated to reflect these changes, and new tests are added to verify correct behavior.

**NO_AUTH_MODE behavior changes:**

* When `NO_AUTH_MODE` is enabled, the application now skips loading both user and traffic data from the database and ignores the `USER_STORE_PATH` variable. This ensures no persistent state is loaded or used in this mode. [[1]](diffhunk://#diff-abbd6017292bdf5c645e0d886693e622bf2d1d7f0893748d194449c9342f6016L53-R66) [[2]](diffhunk://#diff-abbd6017292bdf5c645e0d886693e622bf2d1d7f0893748d194449c9342f6016L172-R186) [[3]](diffhunk://#diff-abbd6017292bdf5c645e0d886693e622bf2d1d7f0893748d194449c9342f6016R209-R215)
* Logging and warning messages are updated to accurately reflect that authentication, admin server, and database-backed state loading are all skipped in `NO_AUTH_MODE`.

**Documentation updates:**

* The `README.md` and `docs/CONFIG.md` files are updated to clarify that `NO_AUTH_MODE` disables authentication, skips admin startup, ignores `USER_STORE_PATH`, and disables database-backed state loading. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L243-R243) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L299-R300) [[3]](diffhunk://#diff-ed97b806cc8d5a740609f925aad9014e8c916832befd26fd8fe632682349c90bL49-R50) [[4]](diffhunk://#diff-ed97b806cc8d5a740609f925aad9014e8c916832befd26fd8fe632682349c90bL238-R238)

**Testing improvements:**

* New unit tests are added to verify that, when `NO_AUTH_MODE` is enabled, database-backed user and traffic stores are not created or used, and that in-memory stores are used instead. [[1]](diffhunk://#diff-ecff4cf331b47e057256e6b79311e4619f85c7c643f2184f85f899eea7c06b4cR40-R59) [[2]](diffhunk://#diff-ecff4cf331b47e057256e6b79311e4619f85c7c643f2184f85f899eea7c06b4cR103-R120)