### PR TITLE
fix(socks5): correct dest_addr logging for unresolved FQDN

### DIFF
--- a/pkg/socks5/request.go
+++ b/pkg/socks5/request.go
@@ -23,7 +23,10 @@ type AddrSpec struct {
 // String returns a string representation of the address
 func (a *AddrSpec) String() string {
 	if a.FQDN != "" {
-		return fmt.Sprintf("%s (%s):%d", a.FQDN, a.IP, a.Port)
+		if a.IP != nil && len(a.IP) > 0 {
+			return fmt.Sprintf("%s (%s):%d", a.FQDN, a.IP, a.Port)
+		}
+		return fmt.Sprintf("%s:%d", a.FQDN, a.Port)
 	}
 	// Check if the address is an IPv6 address
 	if strings.Count(a.IP.String(), ":") > 1 {

--- a/pkg/socks5/socks5.go
+++ b/pkg/socks5/socks5.go
@@ -170,7 +170,6 @@ func (s *Server) handleConnection(conn net.Conn) {
 	request.AuthContext = authContext
 	requestLogger := connLogger.With().
 		Str("command", request.Command.String()).
-		Str("dest_addr", request.DestAddr.String()).
 		Logger()
 	requestLogger.Debug().Msg("request received")
 	trafficSession := s.startTrafficSession(authContext, conn)
@@ -180,13 +179,13 @@ func (s *Server) handleConnection(conn net.Conn) {
 		request.RemoteAddr = &AddrSpec{IP: clientAddr.IP, Port: clientAddr.Port}
 	}
 
-	if err := s.handleRequest(request, conn, trafficSession, requestLogger); err != nil &&
-		shouldLogRequestError(err) {
-		requestLogger.Error().
+	err, updatedLogger := s.handleRequest(request, conn, trafficSession, requestLogger)
+	if err != nil && shouldLogRequestError(err) {
+		updatedLogger.Error().
 			Err(err).
 			Msg("request failed")
 	} else if err == nil {
-		requestLogger.Info().
+		updatedLogger.Info().
 			Str("latency", request.Latency.Round(time.Millisecond).String()).
 			Uint64("upload_bytes", trafficSession.UploadBytes()).
 			Uint64("download_bytes", trafficSession.DownloadBytes()).
@@ -216,19 +215,22 @@ func (s *Server) authenticate(conn net.Conn, bufConn *bufio.Reader) (*Context, e
 	return nil, noAcceptable(conn)
 }
 
-func (s *Server) handleRequest(req *Request, conn net.Conn, trafficSession *traffic.Session, requestLogger zerolog.Logger) error {
+func (s *Server) handleRequest(req *Request, conn net.Conn, trafficSession *traffic.Session, requestLogger zerolog.Logger) (error, zerolog.Logger) {
 	dest := req.DestAddr
 	if dest.FQDN != "" {
 		addr, err := s.config.Resolver.Resolve(dest.FQDN)
 		if err != nil {
 			if err := sendReply(conn, StatusHostUnreachable.Uint8(), nil); err != nil {
-				return fmt.Errorf("%w: %w", ErrFailedToSendReply, err)
+				return fmt.Errorf("%w: %w", ErrFailedToSendReply, err), requestLogger
 			}
-			return fmt.Errorf("failed to resolve destination: %w", err)
+			return fmt.Errorf("failed to resolve destination: %w", err), requestLogger
 		}
 		dest.IP = addr
-		requestLogger.Debug().Str("resolved_ip", addr.String()).Msg("resolved destination address")
+		requestLogger = requestLogger.With().Str("resolved_ip", addr.String()).Logger()
+		requestLogger.Debug().Msg("resolved destination address")
 	}
+	// Update dest_addr with resolved IP for final logging
+	requestLogger = requestLogger.With().Str("dest_addr", dest.String()).Logger()
 
 	req.realAddr = req.DestAddr
 	if s.config.Rewriter != nil {
@@ -237,7 +239,8 @@ func (s *Server) handleRequest(req *Request, conn net.Conn, trafficSession *traf
 
 	switch req.Command {
 	case CommandConnect:
-		return s.handleConnect(conn, req, trafficSession, requestLogger)
+		err := s.handleConnect(conn, req, trafficSession, requestLogger)
+		return err, requestLogger
 	// TODO: Implement these
 	//case CommandBind:
 	//	return s.handleBind(conn, req)
@@ -245,9 +248,9 @@ func (s *Server) handleRequest(req *Request, conn net.Conn, trafficSession *traf
 	//	return s.handleAssociate(conn, req)
 	default:
 		if err := sendReply(conn, StatusCommandNotSupported.Uint8(), nil); err != nil {
-			return fmt.Errorf("%w: %w", ErrFailedToSendReply, err)
+			return fmt.Errorf("%w: %w", ErrFailedToSendReply, err), requestLogger
 		}
-		return fmt.Errorf("unsupported command: %d", req.Command)
+		return fmt.Errorf("unsupported command: %d", req.Command), requestLogger
 	}
 }
 

--- a/pkg/socks5/socks5_test.go
+++ b/pkg/socks5/socks5_test.go
@@ -85,7 +85,8 @@ func (s *Server) testHandleRequest(req *Request, conn net.Conn) error {
 		Str("command", req.Command.String()).
 		Str("dest_addr", req.DestAddr.String()).
 		Logger()
-	return s.handleRequest(req, conn, session, reqLogger)
+	err, _ := s.handleRequest(req, conn, session, reqLogger)
+	return err
 }
 
 func TestNew(t *testing.T) {


### PR DESCRIPTION
This pull request refactors the logging logic in the SOCKS5 server to ensure that destination addresses and resolved IPs are logged more accurately, especially after DNS resolution. It also changes the signature of `handleRequest` to return both an error and an updated logger, allowing for more precise logging throughout the request lifecycle.

**Logging improvements:**

* The `handleRequest` function now returns both an error and an updated `zerolog.Logger`, ensuring that the logger contains the most up-to-date context, such as the resolved destination address. [[1]](diffhunk://#diff-2fcca31a387993bf397f58384287a1349eccbcd6ce0034424267f9d9446f7ee6L219-R233) [[2]](diffhunk://#diff-2fcca31a387993bf397f58384287a1349eccbcd6ce0034424267f9d9446f7ee6L183-R188)
* After DNS resolution, the logger is enriched with the resolved IP and the final destination address, improving the accuracy of log entries.

**Code and interface changes:**

* The `handleRequest` function signature is updated throughout the codebase, including in the test helper, to accommodate the new return type. [[1]](diffhunk://#diff-2fcca31a387993bf397f58384287a1349eccbcd6ce0034424267f9d9446f7ee6L240-R253) [[2]](diffhunk://#diff-8512775d60484e4119b67cc40b78c3ab821503d62cf8714a51048f706639f559L88-R89)
* The logging of the `dest_addr` field is moved to after DNS resolution, so logs always reflect the actual address used for the connection.

**String representation improvements:**

* The `AddrSpec.String()` method is enhanced to handle cases where both FQDN and IP are present, ensuring a clearer string representation for logging and debugging.…S5 server